### PR TITLE
Studying flex.

### DIFF
--- a/studying_flex/styles.css
+++ b/studying_flex/styles.css
@@ -1,0 +1,91 @@
+.wrapper {
+    display: flex;
+}
+
+.field {
+    display: flex;
+    height: 100px;
+    width: 100px;
+    border: 1px solid powderblue;
+    border-radius: 10px;
+    margin: 10px;
+}
+
+.fixed-height {
+    height: 20px;
+}
+.card {
+    /* height: 20px; */
+    width: 10px;
+    border: 1px solid green;
+    border-radius: 10px;
+    background: yellow;
+    text-align: center;
+}
+
+.card-wrapper {
+    display: flex;
+}
+
+section {
+    display: flex;
+}
+.justify-center {
+    justify-content: center;
+}
+
+.justify-start {
+    justify-content: flex-start;
+}
+
+.justify-end {
+    justify-content: flex-end;
+}
+
+.justify-between {
+    justify-content: space-between;
+}
+
+.justify-around {
+    justify-content: space-around;
+}
+
+.justify-evenly {
+    justify-content: space-evenly;
+}
+
+.align-items-center {
+    align-items: center;
+}
+
+.align-items-start {
+    align-items: flex-start;
+}
+
+.align-items-end {
+    align-items: flex-end;
+}
+
+.align-items-baseline {
+    align-items: baseline;
+}
+
+.align-items-stretch {
+    align-items: stretch;
+}
+
+.flex-direction-row {
+    flex-direction: row;
+}
+
+.flex-direction-column {
+    flex-direction: column;
+}
+
+.flex-direction-row-reverse {
+    flex-direction: row-reverse;
+}
+
+.flex-direction-column-reverse {
+    flex-direction: column-reverse;
+}

--- a/studying_flex/test2.html
+++ b/studying_flex/test2.html
@@ -1,0 +1,136 @@
+<html>
+
+<head>
+    <meta charset="UTF-8">
+    <link rel="stylesheet" href="styles.css">
+</head>
+
+<body>
+    <section class="justify-center flex-direction-column">
+        <p>justify-content</p>
+        <div class="wrapper">
+            <div class="card-wrapper justify-center align-items-center flex-direction-column">
+                <p>flex-start</p>
+                <div class="field justify-start">
+                    <div class="card fixed-height">1</div>
+                </div>
+            </div>
+            <div class="card-wrapper justify-center align-items-center flex-direction-column">
+                <p>center</p>
+                <div class="field justify-center">
+                    <div class="card fixed-height">1</div>
+                </div>
+            </div>
+            <div class="card-wrapper justify-center align-items-center flex-direction-column">
+                <p>flex-end</p>
+                <div class="field justify-end">
+                    <div class="card fixed-height">1</div>
+                </div>
+            </div>
+            <div class="card-wrapper justify-center align-items-center flex-direction-column">
+                <p>space-between</p>
+                <div class="field justify-between">
+                    <div class="card fixed-height">1</div>
+                    <div class="card fixed-height">2</div>
+                </div>
+            </div>
+            <div class="card-wrapper justify-center align-items-center flex-direction-column">
+                <p>space-around</p>
+                <div class="field justify-around">
+                    <div class="card fixed-height">1</div>
+                    <div class="card fixed-height">2</div>
+                </div>
+            </div>
+            <div class="card-wrapper justify-center align-items-center flex-direction-column">
+                <p>space-evenly</p>
+                <div class="field justify-evenly">
+                    <div class="card fixed-height">1</div>
+                    <div class="card fixed-height">2</div>
+                </div>
+            </div>
+        </div>
+    </section>
+    <section class="justify-center flex-direction-column">
+        <p>align-items</p>
+        <div class="wrapper">
+            <div class="card-wrapper justify-center align-items-center flex-direction-column">
+                <p>flex-start</p>
+                <div class="field align-items-start">
+                    <div class="card">1</div>
+                </div>
+            </div>
+            <div class="card-wrapper justify-center align-items-center flex-direction-column">
+                <p>center</p>
+                <div class="field align-items-center">
+                    <div class="card">1</div>
+                </div>
+            </div>
+            <div class="card-wrapper justify-center align-items-center flex-direction-column">
+                <p>flex-end</p>
+                <div class="field align-items-end">
+                    <div class="card">1</div>
+                </div>
+            </div>
+            <div class="card-wrapper justify-center align-items-center flex-direction-column">
+                <p>baseline</p>
+                <div class="field align-items-baseline">
+                    <div class="card" style="font-size: 15px;">1</div>
+                    <div class="card" style="font-size: 20px;">2</div>
+                    <div class="card" style="font-size: 25px;">3</div>
+                    <div class="card" style="font-size: 20px;">4</div>
+                    <div class="card" style="font-size: 15px;">5</div>
+                </div>
+            </div>
+            <div class="card-wrapper justify-center align-items-center flex-direction-column">
+                <p>stretch</p>
+                <div class="field align-items-stretch">
+                    <div class="card">1</div>
+                    <div class="card">2</div>
+                    <div class="card">3</div>
+                    <div class="card">4</div>
+                    <div class="card">5</div>
+                </div>
+            </div>
+        </div>
+    </section>
+    <section class="justify-center flex-direction-column">
+        <p>flex-direction</p>
+        <div class="wrapper">
+            <div class="card-wrapper justify-center align-items-center flex-direction-column">
+                <p>row</p>
+                <div class="field flex-direction-row">
+                    <div class="card fixed-height">1</div>
+                    <div class="card fixed-height">2</div>
+                    <div class="card fixed-height">3</div>
+                </div>
+            </div>
+            <div class="card-wrapper justify-center align-items-center flex-direction-column">
+                <p>row-reverse</p>
+                <div class="field flex-direction-row-reverse">
+                    <div class="card fixed-height">1</div>
+                    <div class="card fixed-height">2</div>
+                    <div class="card fixed-height">3</div>
+                </div>
+            </div>
+            <div class="card-wrapper justify-center align-items-center flex-direction-column">  
+                <p>column</p>
+                <div class="field flex-direction-column">
+                    <div class="card fixed-height">1</div>
+                    <div class="card fixed-height">2</div>
+                    <div class="card fixed-height">3</div>
+                </div>
+            </div>
+            <div class="card-wrapper justify-center align-items-center flex-direction-column">
+                <p>column-reverse</p>
+                <div class="field flex-direction-column-reverse">
+                    <div class="card fixed-height">1</div>
+                    <div class="card fixed-height">2</div>
+                    <div class="card fixed-height">3</div>
+                </div>
+            </div>
+        </div>
+    </section>
+</body>
+<!-- <></> -->
+
+</html>


### PR DESCRIPTION
Previously I have added structure for justify-content and align-items, but I have faced a problem with align-items baseline and stretch.

align-items: baseline looked like simple align-items: flex-start. I found out that baseline aligns based on text baselines, so without different text sizes or content, it appears like flex-start. I have added different text sizes.

To solve problem with align-items, I have removed fixed height for every card. That's why my styles broke for other elements in justify-content section. To fix them I have added class with fixed height.

Afterwards I have added section with flex-direction.